### PR TITLE
Add main class declaration in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,3 +24,7 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+application {
+    mainClass = "edu.virginia.sde.javafx.tacos.HotDogVotesApplication"
+}


### PR DESCRIPTION
When I tried to run the app with ./gradlew build, Gradle would fail with the error "No main class specified and classpath is not an executable jar."

This PR fixes that by declaring the main class in build.gradle